### PR TITLE
Add configuration options for old Rocket Creeper behavior

### DIFF
--- a/src/main/java/net/daveyx0/primitivemobs/config/PrimitiveMobsConfigSpecial.java
+++ b/src/main/java/net/daveyx0/primitivemobs/config/PrimitiveMobsConfigSpecial.java
@@ -25,6 +25,8 @@ public class PrimitiveMobsConfigSpecial {
 	public static boolean dodoMycelium;
 	public static boolean travelerVisit;
 	public static boolean spiritEnable;
+	public static boolean rocketCreeperSpawnUnderground;
+	public static boolean rocketCreeperAlwaysJump;
 
 	public static void load(Configuration config) {
 		String category1 = "Mob Specific Settings";
@@ -45,6 +47,8 @@ public class PrimitiveMobsConfigSpecial {
 		travelerVisit = config.get(category1, "Traveling Merchant enters houses", true, "Enable/Disable if the Traveling Merchant should enter houses").getBoolean();
 		spiritEnable = config.get(category1, "Enable (beta) Summons (requires reload)", false, "Enable/Disable experimental Summons feature (requires reload)").getBoolean();
 		spiritOverlay = config.get(category1, "Show the animated overlay on summons", true, "Enable/Disable if summoned entities show the purple animated overlay (client side)").getBoolean();
+		rocketCreeperSpawnUnderground = config.get(category1, "Rocket Creepers spawn without skylight", false, "Enable/Disable if rocket creepers can spawn in places where they cannot see the sky").getBoolean();
+		rocketCreeperAlwaysJump = config.get(category1, "Rocket Creepers always jump, even without adequate room", false, "Enable/Disable if rocket creepers should always jump at the player, even if they would hit the ceiling").getBoolean();
 	}
 	
 	public static String[] getTreasureSlimeLoot()
@@ -130,5 +134,15 @@ public class PrimitiveMobsConfigSpecial {
 	public static boolean getSummonEnable()
 	{
 		return spiritEnable;
+	}
+	
+	public static boolean getRocketCreeperSpawnUnderground()
+	{
+		return rocketCreeperSpawnUnderground;
+	}
+	
+	public static boolean getRocketCreeperAlwaysJump()
+	{
+		return rocketCreeperAlwaysJump;
 	}
 }

--- a/src/main/java/net/daveyx0/primitivemobs/entity/monster/EntityRocketCreeper.java
+++ b/src/main/java/net/daveyx0/primitivemobs/entity/monster/EntityRocketCreeper.java
@@ -97,9 +97,11 @@ public class EntityRocketCreeper extends EntityPrimitiveCreeper {
     public boolean hasEnoughSpaceToJump(Entity entityIn)
     {
     	boolean flag = true;
-    	for(int i = 0; i < 5; i++)
-    	{
-    		flag = this.world.rayTraceBlocks(new Vec3d(this.posX, this.posY + (double)this.getEyeHeight() + i, this.posZ), new Vec3d(entityIn.posX, entityIn.posY + (double)entityIn.getEyeHeight(), entityIn.posZ), false, true, false) == null;
+    	if (!PrimitiveMobsConfigSpecial.getRocketCreeperAlwaysJump()) {
+	    	for(int i = 0; i < 5; i++)
+	    	{
+	    		flag = this.world.rayTraceBlocks(new Vec3d(this.posX, this.posY + (double)this.getEyeHeight() + i, this.posZ), new Vec3d(entityIn.posX, entityIn.posY + (double)entityIn.getEyeHeight(), entityIn.posZ), false, true, false) == null;
+	    	}
     	}
         return flag;
     }
@@ -133,7 +135,7 @@ public class EntityRocketCreeper extends EntityPrimitiveCreeper {
      */
     public boolean getCanSpawnHere()
     {
-    	if(this.world.canSeeSky(new BlockPos(this.posX, this.posY + (double)this.getEyeHeight(), this.posZ)))
+    	if(PrimitiveMobsConfigSpecial.getRocketCreeperSpawnUnderground() || (this.world.canSeeSky(new BlockPos(this.posX, this.posY + (double)this.getEyeHeight(), this.posZ))))
     	{
     		return super.getCanSpawnHere();
     	}


### PR DESCRIPTION
I saw recently that you changed the spawning and jump behavior of the Rocket Creeper. While I understand the reasoning behind these changes, I personally prefer the old behavior. These config options, which are set to use the new behavior by default, allow a player to use the old Rocket Creeper behavior if they prefer.