### PR TITLE
Possible Fix for #17 Invisible Brain Slime

### DIFF
--- a/src/main/java/net/daveyx0/primitivemobs/entity/monster/EntityBrainSlime.java
+++ b/src/main/java/net/daveyx0/primitivemobs/entity/monster/EntityBrainSlime.java
@@ -101,6 +101,11 @@ public class EntityBrainSlime extends EntitySlime implements IMultiMob {
     {
         int i = this.rand.nextInt(3);
         this.setSlimeSize(i, true);
+        if(i == 0)
+        {
+            this.getEntityAttribute(SharedMonsterAttributes.MAX_HEALTH).setBaseValue(2.0);
+            this.setHealth(this.getMaxHealth());
+        }
         return livingdata;
     }
 	


### PR DESCRIPTION
This is based on the theory that Brain Slimes are dying on the client and not the server, so they are still in the world making sounds and jumping on your head, but [invisible](https://github.com/Daveyx0/PrimitiveMobs/issues/17).

Based on how setSlimeSize() works, it seems to me slimes with size 0 end up with 0/0 health. This resets size-0 slimes with 2/2 health for lack of a more elegant solution.

Unfortunately it doesn't explain the inconsistent nature of this bug, which also makes it hard to test. I'm merely hoping it's related.