### PR TITLE
fix input to accept any type of log

### DIFF
--- a/src/main/resources/assets/primitivemobs/recipes/wonder_sap_convert.json
+++ b/src/main/resources/assets/primitivemobs/recipes/wonder_sap_convert.json
@@ -7,8 +7,9 @@
       "data": 32767
     },
     {
-      "item": "minecraft:log",
+      "type": "forge:ore_dict",
       "count": 1,
+      "ore": "logWood",
       "data": 32767
     }
   ],


### PR DESCRIPTION
Currently does not allow minecraft:log2 like acacia nor other modded logs to be used as input
Using "forge:ore_dict" allows log1, log2, and other modded logs to be supported as input for this recipe

Addresses this issue: https://github.com/Daveyx0/PrimitiveMobs/issues/316